### PR TITLE
Fix hang of calendar/fwconsole process

### DIFF
--- a/IcalParser/IcalRangedParser.php
+++ b/IcalParser/IcalRangedParser.php
@@ -88,12 +88,11 @@ class IcalRangedParser extends IcalParser
 			$DTSTARTTimeStamp = $event['DTSTART']->getTimestamp();
 
 			//calc end based on the shortest term
+			$end = $this->ranges['end']->getTimestamp();
 			if ($until !== false) {
 				$untilTm = $until->getTimestamp();
-				$endTm = $this->ranges['end']->getTimestamp();
-				$end = $untilTm < $this->ranges['end']->getTimestamp() ? $untilTm : $endTm;
-			} else
-				$end = $this->ranges['end']->getTimestamp();
+				if ($untilTm < $end) $end = $untilTm;
+			}
 
 			if ($this->fast) {
 				//end is not set on the recurring rule as it is not needed and would cause troubles in the current implementation
@@ -106,14 +105,16 @@ class IcalRangedParser extends IcalParser
 
 				//keep pushing recurrences in the period
 				while (true) {
-					if ($startRange > $end)
-						break; //we are out of maximum range, exit the loop
+					if ($startRange > $end) break; //we are out of maximum range, exit the loop
 
 					$next = $frequency->nextOccurrence($startRange);
-					if ($next != null)
-						array_push($recurrences, $next);
 
-					$startRange = $next + 1; //go to the next recurrence
+					if (is_int($next)) {
+						if ($next < $startRange) break; //this may be an infinite loop! Escape right now!
+						array_push($recurrences, $next);
+						$startRange = $next + 1; //go to the next recurrence
+					} else
+						break; //retrieval failed, probably we are out of period or the recurrence is invalid
 				}
 
 				return $recurrences;
@@ -389,4 +390,3 @@ class IcalRangedParser extends IcalParser
 		return false;
 	}
 }
-

--- a/drivers/Base.php
+++ b/drivers/Base.php
@@ -202,7 +202,7 @@ abstract class Base
 		$start->sub(new \DateInterval(self::SUB_START));
 		$end->add(new \DateInterval(self::ADD_END));
 		$icalData = $this->getIcal();
-		if($icalData){
+		if ($icalData) {
 			$cal = new IcalRangedParser(true);
 			$cal->setStartRange($start);
 			$cal->setEndRange($end);
@@ -211,7 +211,7 @@ abstract class Base
 			$this->calendarClass->setConfig($this->calendar['id'], $start->getTimestamp(), 'calendar-cache_valid_notbefore');
 			$this->calendarClass->setConfig($this->calendar['id'], $end->getTimestamp(), 'calendar-cache_valid_notafter');
 			return true;
-		}else {
+		} else {
 			return false;
 		}
 	}
@@ -224,7 +224,7 @@ abstract class Base
 	public function getCache()
 	{
 		$raw = $this->calendarClass->getConfig($this->calendar['id'], 'calendar-cache');
-		return $raw ? unserialize($this->calendarClass->getConfig($this->calendar['id'], 'calendar-cache')) : null;
+		return $raw ? unserialize($raw) : null;
 	}
 
 	/**
@@ -332,7 +332,6 @@ abstract class Base
 		$now = $this->now->getTimestamp();
 
 		try {
-			checkrange:
 			if (!$this->isInCacheRange($now)) {
 				//if the time is not in range we calculate a short period in a temporary cache (then discarded).
 				//the side effect is that this slows down things very much like is not fast at all, but better than returning nothing.
@@ -347,17 +346,18 @@ abstract class Base
 				$cal->setEndRange($end);
 				$cache = $cal->parseString($this->getIcal());
 			} else {
-				//retrieve the cache if in range
-				$cache = $this->getCache();
-				if (!$cache)
-					throw new Exception(); //should never happen because of isInCacheRange(). Anyway lets build the cache if this happens
+				$cache = $this->getCache(); //retrieve the cache if in range
+				if (!$cache) throw new Exception(); //should never happen because of isInCacheRange(). Anyway lets build the cache if this happens
 			}
 		} catch (Exception $ignored) {
 			//cache not built yet, build it for the first time. This should happen only once, then sync will take care
-			if($this->buildCache()){
-				goto checkrange;
-			} else {
+			$this->processCalendar(); //we cannot rely on the return value of this call because every driver treat it differently (or return nothing at all)...
+
+			if ($this->buildCache()) //...so we call buildCache() again to get a consistent result
+				return $this->fastHandler();
+			else {
 				dbug(' No matching Data');
+				return false;
 			}
 		}
 
@@ -588,4 +588,3 @@ abstract class Base
 		return false;
 	}
 }
-


### PR DESCRIPTION
As long-windedly discussed on [FreePBX forum](https://community.freepbx.org/t/calendar-module-update-16-0-28/94279) the last updates (16.0.23 and up) caused hanging of the fwconsole process and the inability to view the calendar inside the admin UI. This was in particular true only for a specific type of events that contains the following (omitted non relevant values):
```
[DTSTART] => DateTime Object
    (
        [date] => 2022-12-02 08:30:00.000000
        [timezone_type] => 3
        [timezone] => America/New_York
    )
[DTEND] => DateTime Object
    (
        [date] => 2022-12-02 14:00:00.000000
        [timezone_type] => 3
        [timezone] => America/New_York
    )
[RRULE] => Array
    (
        [FREQ] => MONTHLY
        [INTERVAL] => 1
        [UNTIL] => DateTime Object
            (
                [date] => 2022-12-04 00:00:00.000000
                [timezone_type] => 2
                [timezone] => Z
            )

        [BYMONTHDAY] => 2
    )
```
The UNTIL rule was causing the IcalParser library to fail and return an error that was not correctly handled by the code. Now a check is added for the return value and also to be sure that the returned value is greater than the start time of the event.

Inside the same PR I removed a goto statement in Base.php and fixed the return value of `fastHandler()` when no cache is available.