### PR TITLE
fix(calendar): getNextEventByGroup returns false instead of empty array

### DIFF
--- a/Calendar.class.php
+++ b/Calendar.class.php
@@ -1112,13 +1112,13 @@ class Calendar extends \DB_Helper implements \BMO
 			$cal = $this->getDriverById($calid);
 			$cal->setTimezone($timezone);
 			$cal->setNow($now);
-			$ev = $cal->getNextEvent($cal);
+			$ev = $cal->getNextEvent();
 			if (!empty($ev)) {
 				$events[$ev['startdate']] = $ev;
 			}
 		}
 		ksort($events);
-		return reset($events);
+		return !empty($events) ? reset($events) : [];
 	}
 
 	/**


### PR DESCRIPTION
## Summary

`Calendar::getNextEventByGroup()` returns `false` when no calendars in a group have upcoming events. This violates the method's own `@return array` docblock and is inconsistent with `Base::getNextEvent()` which correctly returns `[]`.

### Root Cause

When the `\$events` array is empty after iterating all calendars in the group, `reset(\$events)` returns `false` — documented PHP behavior for `reset()` on empty arrays. The method should return `[]` to honor its contract.

### Impact

The `false` return value causes a downstream crash in the **timeconditions** module. Both `schedtc.php` and `Job.php` access `\$next['startdate']` on the return value — PHP 8.x throws a fatal `Undefined array key` error on `false`, terminating the time condition evaluation loop and preventing BLF hint updates.

### Fix

1. Return `[]` explicitly when `\$events` is empty, matching the behavior of `Base::getNextEvent()` and the `@return` docblock contract
2. Remove spurious `\$cal` argument passed to the driver-level `getNextEvent()` which accepts zero parameters (harmless but incorrect)

### Environment

- FreePBX 17 / PBXact 17
- PHP 8.1+ (Debian 12)
- Same bug exists in `release/16.0`

### Related

- Companion PR for the timeconditions crash site: https://github.com/FreePBX/timeconditions/pull/23
- Community thread (same symptom chain): https://community.freepbx.org/t/freepbx-bug-blf-subscriptions/106007

---

*Discovered during fleet maintenance by Aaron Salsitz (Master Bitherder) at [ICCI, LLC](https://icci.com). Analysis and fix developed with [Claude Code](https://claude.ai/code).*