### PR TITLE
issue 682 recurrent events fix 2

### DIFF
--- a/IcalParser/IcalRangedParser.php
+++ b/IcalParser/IcalRangedParser.php
@@ -451,6 +451,12 @@ class IcalRangedParser extends \om\IcalParser
 							$instEnd = $this->getMonthlyClampedEnd($rs, $event['DTSTART'], $event['DTEND']);
 							$duration = $instEnd->getTimestamp() - $recurrenceTimestamp;
 						}
+						if(
+							gettype($recurrenceTimestamp) === "object" &&
+							get_class($recurrenceTimestamp) === "DateTime"
+						){
+							$recurrenceTimestamp = $recurrenceTimestamp->getTimestamp();
+						}
 						if ($now > $recurrenceTimestamp && $now < ($recurrenceTimestamp + $duration)) {
 							array_push($events, $event); //at least one recurrence is now, keep it
 							continue 2; //go to the next event


### PR DESCRIPTION
See [issue 682](https://github.com/FreePBX/issue-tracker/issues/682#issuecomment-2821422569) for information.

The tests with $recurrenceTimestamp show it's always expected to be an integer, which is not the case. Sometimes, it's a DateTime.

This change has been tested with recurring events, "normal" events and no events for :
- local calendar
- nextcloud iCal
- nextcloud CalDAV
- google iCal (the only one I found where $recurrenceTimestamp is an integer)
